### PR TITLE
add Zipkin 

### DIFF
--- a/src/datanode/setup.go
+++ b/src/datanode/setup.go
@@ -2,6 +2,7 @@ package datanode
 
 import (
 	"context"
+	"fmt"
 	zipkingrpc "github.com/openzipkin/zipkin-go/middleware/grpc"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -26,7 +27,7 @@ func (s *dataNodeServer) Setup(ctx context.Context) {
 		log.Panic(err)
 	}
 	//zipkin
-	tracer, r, err := utils.NewZipkinTracer(utils.ZIPKIN_HTTP_ENDPOINT, "dataNodeServer", s.addr)
+	tracer, r, err := utils.NewZipkinTracer(utils.ZIPKIN_HTTP_ENDPOINT, fmt.Sprintf("%sDataNode", s.addr), s.addr)
 	defer r.Close()
 	if err != nil {
 		log.Println(err)

--- a/src/datanode/setup.go
+++ b/src/datanode/setup.go
@@ -2,6 +2,7 @@ package datanode
 
 import (
 	"context"
+	zipkingrpc "github.com/openzipkin/zipkin-go/middleware/grpc"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"net"
@@ -24,14 +25,21 @@ func (s *dataNodeServer) Setup(ctx context.Context) {
 	if err != nil {
 		log.Panic(err)
 	}
-
+	//zipkin
+	tracer, r, err := utils.NewZipkinTracer(utils.ZIPKIN_HTTP_ENDPOINT, "dataNodeServer", s.addr)
+	defer r.Close()
+	if err != nil {
+		log.Println(err)
+		return
+	}
 	// setup datanode server
 	log.Infof("starting datanode server %v", s.addr)
 	listener, err := net.Listen("tcp", s.addr)
 	if err != nil {
 		log.Panic(err)
 	}
-	server := grpc.NewServer()
+
+	server := grpc.NewServer(grpc.StatsHandler(zipkingrpc.NewServerHandler(tracer)))
 	protos.RegisterDataNodeServer(server, s)
 
 	go func() {

--- a/src/namenode/setup.go
+++ b/src/namenode/setup.go
@@ -44,7 +44,7 @@ func (s *nameNodeServer) Setup(ctx context.Context) {
 	// setup cluster
 	s.setupCluster()
 	//zipkin
-	tracer, r, err := utils.NewZipkinTracer(utils.ZIPKIN_HTTP_ENDPOINT, "nameNodeServer", s.addr)
+	tracer, r, err := utils.NewZipkinTracer(utils.ZIPKIN_HTTP_ENDPOINT, fmt.Sprintf("%sNameNode", s.addr), s.addr)
 	defer r.Close()
 	if err != nil {
 		log.Println(err)

--- a/src/utils/connection.go
+++ b/src/utils/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	zipkingrpc "github.com/openzipkin/zipkin-go/middleware/grpc"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -12,7 +13,14 @@ import (
 )
 
 func ConnectToTargetDataNode(addr string) (protos.DataNodeClient, *grpc.ClientConn, error) {
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	//zipkin
+	tracer, r, err := NewZipkinTracer(ZIPKIN_HTTP_ENDPOINT, "ConnectToTargetDataNode", addr)
+	defer r.Close()
+	if err != nil {
+		log.Println(err)
+		return nil, nil, nil
+	}
+	conn, err := grpc.Dial(addr, grpc.WithStatsHandler(zipkingrpc.NewClientHandler(tracer)), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -20,7 +28,14 @@ func ConnectToTargetDataNode(addr string) (protos.DataNodeClient, *grpc.ClientCo
 }
 
 func ConnectToTargetNameNode(addr string, readonly bool) (protos.NameNodeClient, *grpc.ClientConn, error) {
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	//zipkin
+	tracer, r, err := NewZipkinTracer(ZIPKIN_HTTP_ENDPOINT, "ConnectToTargetNameNode", addr)
+	defer r.Close()
+	if err != nil {
+		log.Println(err)
+		return nil, nil, nil
+	}
+	conn, err := grpc.Dial(addr, grpc.WithStatsHandler(zipkingrpc.NewClientHandler(tracer)), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/src/utils/connection.go
+++ b/src/utils/connection.go
@@ -14,7 +14,7 @@ import (
 
 func ConnectToTargetDataNode(addr string) (protos.DataNodeClient, *grpc.ClientConn, error) {
 	//zipkin
-	tracer, r, err := NewZipkinTracer(ZIPKIN_HTTP_ENDPOINT, "ConnectToTargetDataNode", addr)
+	tracer, r, err := NewZipkinTracer(ZIPKIN_HTTP_ENDPOINT, fmt.Sprintf("-->%sDataNode", addr), addr)
 	defer r.Close()
 	if err != nil {
 		log.Println(err)
@@ -29,7 +29,7 @@ func ConnectToTargetDataNode(addr string) (protos.DataNodeClient, *grpc.ClientCo
 
 func ConnectToTargetNameNode(addr string, readonly bool) (protos.NameNodeClient, *grpc.ClientConn, error) {
 	//zipkin
-	tracer, r, err := NewZipkinTracer(ZIPKIN_HTTP_ENDPOINT, "ConnectToTargetNameNode", addr)
+	tracer, r, err := NewZipkinTracer(ZIPKIN_HTTP_ENDPOINT, fmt.Sprintf("-->%sDataNode", addr), addr)
 	defer r.Close()
 	if err != nil {
 		log.Println(err)

--- a/src/utils/zipkin.go
+++ b/src/utils/zipkin.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go/reporter"
+	httpreport "github.com/openzipkin/zipkin-go/reporter/http"
+)
+
+const (
+	ZIPKIN_HTTP_ENDPOINT = "http://127.0.0.1:9411/api/v2/spans" //上报到ZipKin中的链路
+
+)
+
+// 创建一个zipkin追踪器
+// url:http://localhost:9411/api/v2/spans
+// serviceName:服务名，Endpoint标记
+// hostPort：ip:port，Endpoint标记
+func NewZipkinTracer(url, serviceName, hostPort string) (*zipkin.Tracer, reporter.Reporter, error) {
+
+	// 初始化zipkin reporter
+	// reporter可以有很多种，如：logReporter、httpReporter，这里我们只使用httpReporter将span报告给http服务，也就是zipkin的http后台
+	r := httpreport.NewReporter(url)
+
+	//创建一个endpoint，用来标识当前服务，服务名：服务地址和端口
+	endpoint, err := zipkin.NewEndpoint(serviceName, hostPort)
+	if err != nil {
+		return nil, r, err
+	}
+
+	// 初始化追踪器 主要作用有解析span，解析上下文等
+	tracer, err := zipkin.NewTracer(r, zipkin.WithLocalEndpoint(endpoint))
+	if err != nil {
+		return nil, r, err
+	}
+
+	return tracer, r, nil
+}

--- a/src/utils/zipkin.go
+++ b/src/utils/zipkin.go
@@ -7,27 +7,22 @@ import (
 )
 
 const (
-	ZIPKIN_HTTP_ENDPOINT = "http://127.0.0.1:9411/api/v2/spans" //上报到ZipKin中的链路
-
+	ZIPKIN_HTTP_ENDPOINT = "http://127.0.0.1:9411/api/v2/spans"
 )
 
-// 创建一个zipkin追踪器
-// url:http://localhost:9411/api/v2/spans
-// serviceName:服务名，Endpoint标记
-// hostPort：ip:port，Endpoint标记
+// NewZipkinTracer creat a zipkin Tracer
 func NewZipkinTracer(url, serviceName, hostPort string) (*zipkin.Tracer, reporter.Reporter, error) {
 
-	// 初始化zipkin reporter
-	// reporter可以有很多种，如：logReporter、httpReporter，这里我们只使用httpReporter将span报告给http服务，也就是zipkin的http后台
+	// init zipkin reporter
 	r := httpreport.NewReporter(url)
 
-	//创建一个endpoint，用来标识当前服务，服务名：服务地址和端口
+	//creat a endpoint，used to identify the current service, service name: service address and port
 	endpoint, err := zipkin.NewEndpoint(serviceName, hostPort)
 	if err != nil {
 		return nil, r, err
 	}
 
-	// 初始化追踪器 主要作用有解析span，解析上下文等
+	// Initialize the tracker to parse span and context
 	tracer, err := zipkin.NewTracer(r, zipkin.WithLocalEndpoint(endpoint))
 	if err != nil {
 		return nil, r, err


### PR DESCRIPTION
通过在grpc加入了tracer,增加了链路追踪功能，使用时需提前运行容器
`
docker run -d -p 9411:9411 openzipkin/zipkin
`
然后在浏览器中打开
`http://127.0.0.1:9411/zipkin/`